### PR TITLE
Extend diagram API timeout and add 404 page

### DIFF
--- a/app/api/generate-preview-diagrams/route.ts
+++ b/app/api/generate-preview-diagrams/route.ts
@@ -5,7 +5,7 @@ import { ServerPromptService } from "@/lib/prompt-service-server"
 import { createClient } from '@supabase/supabase-js'
 import { anonymousProjectService } from '@/lib/anonymous-project-service'
 
-export const maxDuration = 30
+export const maxDuration = 60
 
 interface PreviewDiagramsRequest {
   input: string

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 gap-4">
+      <h1 className="text-4xl font-bold">404 - Page Not Found</h1>
+      <p className="text-gray-500">Sorry, the page you requested could not be found.</p>
+      <Button asChild>
+        <Link href="/">Return Home</Link>
+      </Button>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- extend diagram generation API timeout from 30s to 60s so larger diagrams can be processed
- add a new `app/not-found.tsx` to display a friendly 404 page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c9a116654832a8f926ab94592871b